### PR TITLE
Added support for 'enabled' parameter for monitors

### DIFF
--- a/device_config.js
+++ b/device_config.js
@@ -6,7 +6,7 @@ var DeviceConfig = module.exports = function() {
   this._remoteUpdate = null;
   this._remoteDestroy = null;
   this.streams = {};
-  this.monitors = [];
+  this.monitors = {};
   this.allowed = {};
   this.transitions = {};
 };
@@ -44,8 +44,18 @@ DeviceConfig.prototype.map = function(name, handler, fields) {
   return this;
 };
 
-DeviceConfig.prototype.monitor = function(name) {
-  this.monitors.push(name);
+DeviceConfig.prototype.monitor = function(name, enabled) {
+  // default to enabled if not provided
+  if(enabled === undefined) {
+    enabled = true;
+  } else {
+    enabled = !!enabled;
+  }
+
+  this.monitors[name] = {
+    enabled: enabled
+  };
+  
   return this;
 };
 

--- a/device_config.js
+++ b/device_config.js
@@ -44,18 +44,11 @@ DeviceConfig.prototype.map = function(name, handler, fields) {
   return this;
 };
 
-DeviceConfig.prototype.monitor = function(name, enabled) {
-  // default to enabled if not provided
-  if(enabled === undefined) {
-    enabled = true;
-  } else {
-    enabled = !!enabled;
-  }
-
+DeviceConfig.prototype.monitor = function(name, options) {
   this.monitors[name] = {
-    enabled: enabled
+    options: options
   };
-  
+
   return this;
 };
 


### PR DESCRIPTION
I have several monitors what are used for debug purposes and I would like to default to disabled.  This isn't possible to do in the current implementation of the `init()` process because he streams aren't created when you call `config.monitor()` but rather after the `init()` function has returned.

See also zettajs/zetta-device#16
