### PR TITLE
Added support for 'enabled' parameter for monitors with backwards compatibility.

### DIFF
--- a/device_config.js
+++ b/device_config.js
@@ -6,7 +6,7 @@ var DeviceConfig = module.exports = function() {
   this._remoteUpdate = null;
   this._remoteDestroy = null;
   this.streams = {};
-  this.monitors = [];
+  this.monitors = {};
   this.allowed = {};
   this.transitions = {};
 };
@@ -44,8 +44,18 @@ DeviceConfig.prototype.map = function(name, handler, fields) {
   return this;
 };
 
-DeviceConfig.prototype.monitor = function(name) {
-  this.monitors.push(name);
+DeviceConfig.prototype.monitor = function(name, enabled) {
+  // default to enabled if not provided
+  if(enabled === undefined) {
+    enabled = true;
+  } else {
+    enabled = !!enabled;
+  }
+
+  this.monitors[name] = {
+    enabled: enabled
+  };
+  
   return this;
 };
 

--- a/device_config.js
+++ b/device_config.js
@@ -6,7 +6,8 @@ var DeviceConfig = module.exports = function() {
   this._remoteUpdate = null;
   this._remoteDestroy = null;
   this.streams = {};
-  this.monitors = {};
+  this.monitors = [];
+  this.monitorsOptions = {};
   this.allowed = {};
   this.transitions = {};
 };
@@ -45,10 +46,8 @@ DeviceConfig.prototype.map = function(name, handler, fields) {
 };
 
 DeviceConfig.prototype.monitor = function(name, options) {
-  this.monitors[name] = {
-    options: options
-  };
-
+  this.monitors.push(name);
+  this.monitorsOptions[name] = options || {};
   return this;
 };
 

--- a/device_config.js
+++ b/device_config.js
@@ -44,18 +44,11 @@ DeviceConfig.prototype.map = function(name, handler, fields) {
   return this;
 };
 
-DeviceConfig.prototype.monitor = function(name, enabled) {
-  // default to enabled if not provided
-  if(enabled === undefined) {
-    enabled = true;
-  } else {
-    enabled = !!enabled;
-  }
-
+DeviceConfig.prototype.monitor = function(name, options) {
   this.monitors[name] = {
-    enabled: enabled
+    options: options
   };
-  
+
   return this;
 };
 


### PR DESCRIPTION
Exact same as #4 but allows for old device drivers to work with zetta. Needs https://github.com/zettajs/zetta-device/pull/17
