### PR TITLE
:sparkles: Allow ES6 classes

### DIFF
--- a/scientist.js
+++ b/scientist.js
@@ -35,8 +35,7 @@ exports.create = function(/* constructor, ...constructorArgs */) {
   var machine;
 
   if (constructor.prototype) {
-    machine = Object.create(constructor.prototype);
-    machine.constructor.apply(machine, constructorArgs);
+    machine = new (Function.prototype.bind.apply(constructor, [null].concat(constructorArgs)));
   } else if (constructor.init) {
     machine = constructor;
   }


### PR DESCRIPTION
This stays ES5 compatible and allow usage of ES6 classes. See [this link](http://stackoverflow.com/questions/1606797/use-of-apply-with-new-operator-is-this-possible) for the explanation.

Basically, this allow this smoother syntax: 

```js
const util = require('util')
const Scout = require('zetta-scout')

// "Old" syntax

const TestScout = function () {
  Scout.call(this)
}
util.inherits(TestScout, Scout)

TestScout.prototype.init = function (next) {
  next()
}

// "New" syntax

class TestScoutEs2015 extends Scout {
  init (next) {
    next()
  }
}
```

Both syntaxes still work with this PR.